### PR TITLE
Normalize joined view projection columns

### DIFF
--- a/src/Chimpiler.Core/ViewSqlGenerator.cs
+++ b/src/Chimpiler.Core/ViewSqlGenerator.cs
@@ -64,6 +64,7 @@ public class ViewSqlGenerator
 
         // Generate SQL from the lambda
         var viewSql = GenerateSqlFromLambda(lambda, context, contextType, entityType, definitionExpr);
+        viewSql = NormalizeProjectedColumns(viewSql, entityType, definitionExpr);
 
         // Validate the SQL columns match the entity properties
         ValidateViewColumns(entityType, viewSql, viewName);
@@ -555,11 +556,199 @@ public class ViewSqlGenerator
         return null;
     }
 
+    private string NormalizeProjectedColumns(string sql, IEntityType entityType, LambdaExpression? definitionExpr)
+    {
+        if (definitionExpr == null)
+        {
+            return sql;
+        }
+
+        var projectedColumns = GetProjectedViewColumnNames(definitionExpr, entityType);
+        if (projectedColumns.Count == 0)
+        {
+            return sql;
+        }
+
+        if (!TrySplitSelectStatement(sql, out var selectClause, out var fromClause))
+        {
+            return sql;
+        }
+
+        var actualSelectParts = SplitSelectColumns(selectClause);
+        if (actualSelectParts.Count < projectedColumns.Count)
+        {
+            return sql;
+        }
+
+        var normalizedParts = new List<string>(projectedColumns.Count);
+        var changed = actualSelectParts.Count != projectedColumns.Count;
+
+        for (var i = 0; i < projectedColumns.Count; i++)
+        {
+            var normalizedPart = EnsureProjectionAlias(actualSelectParts[i], projectedColumns[i]);
+            normalizedParts.Add(normalizedPart);
+
+            if (!string.Equals(normalizedPart, actualSelectParts[i].Trim(), StringComparison.Ordinal))
+            {
+                changed = true;
+            }
+        }
+
+        if (!changed)
+        {
+            return sql;
+        }
+
+        if (actualSelectParts.Count > projectedColumns.Count)
+        {
+            Log($"Projection normalization trimmed {actualSelectParts.Count - projectedColumns.Count} hidden column(s) from {entityType.Name}.");
+        }
+
+        return $"SELECT {string.Join(", ", normalizedParts)} {fromClause}";
+    }
+
+    private static bool TrySplitSelectStatement(string sql, out string selectClause, out string fromClause)
+    {
+        var match = Regex.Match(
+            sql,
+            @"^\s*SELECT\s+(?<select>.*?)\s+(?<from>FROM\s+.*)$",
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        if (!match.Success)
+        {
+            selectClause = string.Empty;
+            fromClause = string.Empty;
+            return false;
+        }
+
+        selectClause = match.Groups["select"].Value;
+        fromClause = match.Groups["from"].Value.Trim();
+        return true;
+    }
+
+    private List<string> GetProjectedViewColumnNames(LambdaExpression definitionExpr, IEntityType viewEntityType)
+    {
+        var projectionLambda = ExtractProjectionLambda(definitionExpr.Body);
+        if (projectionLambda?.Body is not MemberInitExpression memberInit)
+        {
+            return [];
+        }
+
+        var projectedColumns = new List<string>(memberInit.Bindings.Count);
+        foreach (var binding in memberInit.Bindings)
+        {
+            if (binding is not MemberAssignment assignment)
+            {
+                return [];
+            }
+
+            projectedColumns.Add(GetViewColumnName(viewEntityType, assignment.Member.Name));
+        }
+
+        return projectedColumns;
+    }
+
+    private static LambdaExpression? ExtractProjectionLambda(Expression expr)
+    {
+        if (expr is not MethodCallExpression call)
+        {
+            return null;
+        }
+
+        if (call.Method.Name == "Select" && call.Arguments.Count >= 2)
+        {
+            return UnwrapQuotedLambda(call.Arguments[1]);
+        }
+
+        if (call.Method.Name == "Join" && call.Arguments.Count >= 5)
+        {
+            return UnwrapQuotedLambda(call.Arguments[4]);
+        }
+
+        return null;
+    }
+
+    private static LambdaExpression? UnwrapQuotedLambda(Expression expr)
+    {
+        if (expr is UnaryExpression unary && unary.NodeType == ExpressionType.Quote)
+        {
+            expr = unary.Operand;
+        }
+
+        return expr as LambdaExpression;
+    }
+
+    private string EnsureProjectionAlias(string selectPart, string expectedColumnName)
+    {
+        var trimmedPart = selectPart.Trim();
+        var actualOutputColumnName = ParseOutputColumnName(trimmedPart);
+        if (string.Equals(actualOutputColumnName, expectedColumnName, StringComparison.OrdinalIgnoreCase))
+        {
+            return trimmedPart;
+        }
+
+        var expressionWithoutAlias = Regex.Replace(
+            trimmedPart,
+            @"\s+AS\s+\[[^\]]+\]\s*$",
+            string.Empty,
+            RegexOptions.IgnoreCase);
+
+        return $"{expressionWithoutAlias} AS [{expectedColumnName}]";
+    }
+
+    private string? ParseOutputColumnName(string selectPart)
+    {
+        var aliasMatch = Regex.Match(selectPart, @"AS\s+\[([^\]]+)\]\s*$", RegexOptions.IgnoreCase);
+        if (aliasMatch.Success)
+        {
+            return aliasMatch.Groups[1].Value;
+        }
+
+        var columnMatch = Regex.Match(selectPart, @"\[([^\]]+)\]\s*$");
+        return columnMatch.Success
+            ? columnMatch.Groups[1].Value
+            : null;
+    }
+
+    private IEnumerable<string> GetExpectedViewColumnNames(IEntityType entityType)
+    {
+        foreach (var property in entityType.GetProperties())
+        {
+            yield return property.GetColumnName();
+        }
+
+        foreach (var navigation in entityType.GetNavigations())
+        {
+            if (!navigation.TargetEntityType.IsMappedToJson())
+            {
+                continue;
+            }
+
+            yield return GetViewColumnName(entityType, navigation.Name);
+        }
+    }
+
+    private string GetViewColumnName(IEntityType viewEntityType, string memberName)
+    {
+        var property = viewEntityType.FindProperty(memberName);
+        if (property != null)
+        {
+            return property.GetColumnName();
+        }
+
+        var navigation = viewEntityType.FindNavigation(memberName);
+        if (navigation?.TargetEntityType.IsMappedToJson() == true)
+        {
+            return navigation.TargetEntityType.GetContainerColumnName() ?? memberName;
+        }
+
+        return memberName;
+    }
+
     private void ValidateViewColumns(IEntityType entityType, string sql, string viewName)
     {
         // Get expected columns from the entity
-        var expectedColumns = entityType.GetProperties()
-            .Select(p => p.GetColumnName())
+        var expectedColumns = GetExpectedViewColumnNames(entityType)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         // Parse SQL to get actual columns

--- a/tests/Chimpiler.TestFixtures/TestDbContexts.cs
+++ b/tests/Chimpiler.TestFixtures/TestDbContexts.cs
@@ -906,3 +906,140 @@ public class RedactedEnrollmentView
     public DateTime? CompletedAtUtc { get; set; }
     public EnrollmentPlanPayload? PlanPayload { get; set; }
 }
+
+/// <summary>
+/// Reproduces a joined view where EF Core's SQL includes hidden materialization keys
+/// when JSON-owned projections and renamed/computed columns are present.
+/// </summary>
+public class JoinedEnrollmentContext : DbContext
+{
+    public DbSet<JoinedEnrollmentRecord> JoinedEnrollmentRecords { get; set; } = null!;
+    public DbSet<ParticipantProfileRecord> ParticipantProfileRecords { get; set; } = null!;
+    public DbSet<JoinedParticipantProfileView> JoinedParticipantProfileViews { get; set; } = null!;
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        if (!optionsBuilder.IsConfigured)
+        {
+            optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=JoinedEnrollmentDb;Trusted_Connection=True;");
+        }
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<JoinedEnrollmentRecord>(entity =>
+        {
+            entity.ToTable("JoinedEnrollmentRecords");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).UseIdentityColumn();
+            entity.Property(e => e.ParticipantId).IsRequired();
+            entity.Property(e => e.TenantStudyId).IsRequired();
+            entity.Property(e => e.PseudonymousSubjectNumber).IsRequired();
+            entity.Property(e => e.CreatedAtUtc).IsRequired();
+            entity.Property(e => e.LastSeenAtUtc).IsRequired();
+            entity.HasIndex(e => new { e.TenantStudyId, e.PseudonymousSubjectNumber }).IsUnique();
+
+            entity.OwnsOne(e => e.PlanPayload, b =>
+            {
+                b.ToJson();
+                b.OwnsMany(p => p.ScheduledItems);
+            });
+        });
+
+        modelBuilder.Entity<ParticipantProfileRecord>(entity =>
+        {
+            entity.ToTable("ParticipantProfileRecords");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Id).UseIdentityColumn();
+            entity.Property(e => e.ParticipantId).IsRequired();
+            entity.HasIndex(e => e.ParticipantId).IsUnique();
+
+            entity.OwnsOne(e => e.BackgroundPayload, b =>
+            {
+                b.ToJson();
+                b.OwnsMany(p => p.Flags);
+            });
+        });
+
+        modelBuilder.Entity<JoinedParticipantProfileView>(entity =>
+        {
+            entity.ToView("JoinedParticipantProfileView")
+                .HasViewDefinition<JoinedParticipantProfileView, JoinedEnrollmentContext>(ctx =>
+                    from enrollment in ctx.JoinedEnrollmentRecords.AsNoTracking()
+                    join profile in ctx.ParticipantProfileRecords.AsNoTracking() on enrollment.ParticipantId equals profile.ParticipantId
+                    select new JoinedParticipantProfileView
+                    {
+                        TenantStudyId = enrollment.TenantStudyId,
+                        ScopedSubjectNumber = enrollment.PseudonymousSubjectNumber,
+                        BirthYear = profile.BirthDate.HasValue ? profile.BirthDate.Value.Year : 0,
+                        BackgroundPayload = profile.BackgroundPayload,
+                        CreatedAtUtc = enrollment.CreatedAtUtc,
+                        LastSeenAtUtc = enrollment.LastSeenAtUtc,
+                        WithdrawnAtUtc = enrollment.WithdrawnAtUtc,
+                        CompletedAtUtc = enrollment.CompletedAtUtc,
+                        PlanPayload = enrollment.PlanPayload
+                    })
+                .WithSchemaBinding()
+                .HasClusteredIndex(v => new { v.TenantStudyId, v.ScopedSubjectNumber });
+
+            entity.HasKey(v => new { v.TenantStudyId, v.ScopedSubjectNumber });
+
+            entity.OwnsOne(v => v.BackgroundPayload, b =>
+            {
+                b.ToJson();
+                b.OwnsMany(p => p.Flags);
+            });
+
+            entity.OwnsOne(v => v.PlanPayload, b =>
+            {
+                b.ToJson();
+                b.OwnsMany(p => p.ScheduledItems);
+            });
+        });
+    }
+}
+
+public class JoinedEnrollmentRecord
+{
+    public int Id { get; set; }
+    public int ParticipantId { get; set; }
+    public int TenantStudyId { get; set; }
+    public int PseudonymousSubjectNumber { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime LastSeenAtUtc { get; set; }
+    public DateTime? WithdrawnAtUtc { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+    public EnrollmentPlanPayload? PlanPayload { get; set; }
+}
+
+public class ParticipantProfileRecord
+{
+    public int Id { get; set; }
+    public int ParticipantId { get; set; }
+    public DateTime? BirthDate { get; set; }
+    public ParticipantBackgroundPayload? BackgroundPayload { get; set; }
+}
+
+public class ParticipantBackgroundPayload
+{
+    public string? Summary { get; set; }
+    public List<ParticipantBackgroundFlag> Flags { get; set; } = new();
+}
+
+public class ParticipantBackgroundFlag
+{
+    public string Value { get; set; } = string.Empty;
+}
+
+public class JoinedParticipantProfileView
+{
+    public int TenantStudyId { get; set; }
+    public int ScopedSubjectNumber { get; set; }
+    public int BirthYear { get; set; }
+    public ParticipantBackgroundPayload? BackgroundPayload { get; set; }
+    public DateTime CreatedAtUtc { get; set; }
+    public DateTime LastSeenAtUtc { get; set; }
+    public DateTime? WithdrawnAtUtc { get; set; }
+    public DateTime? CompletedAtUtc { get; set; }
+    public EnrollmentPlanPayload? PlanPayload { get; set; }
+}

--- a/tests/Chimpiler.TestFixtures/TestDbContexts.cs
+++ b/tests/Chimpiler.TestFixtures/TestDbContexts.cs
@@ -773,75 +773,75 @@ public class AuditLog
 /// EF Core's LINQ translator cannot convert such a projection to SQL via ToQueryString(),
 /// so the ViewSqlGenerator must fall back to expression-tree analysis.
 /// </summary>
-public class EnrollmentContext : DbContext
+public class ShipmentContext : DbContext
 {
-    public DbSet<EnrollmentRecord> EnrollmentRecords { get; set; } = null!;
-    public DbSet<RedactedEnrollmentView> RedactedEnrollmentViews { get; set; } = null!;
+    public DbSet<ShipmentRecord> ShipmentRecords { get; set; } = null!;
+    public DbSet<ShipmentSnapshotView> ShipmentSnapshotViews { get; set; } = null!;
     /// <summary>A sibling view that only projects scalar columns (must keep working).</summary>
-    public DbSet<EnrollmentSummaryView> EnrollmentSummaryViews { get; set; } = null!;
+    public DbSet<ShipmentSummaryView> ShipmentSummaryViews { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         if (!optionsBuilder.IsConfigured)
         {
-            optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=EnrollmentDb;Trusted_Connection=True;");
+            optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=ShipmentDb;Trusted_Connection=True;");
         }
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         // ── Base table ──────────────────────────────────────────────────────────
-        modelBuilder.Entity<EnrollmentRecord>(entity =>
+        modelBuilder.Entity<ShipmentRecord>(entity =>
         {
-            entity.ToTable("EnrollmentRecords");
+            entity.ToTable("ShipmentRecords");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Id).UseIdentityColumn();
-            entity.Property(e => e.TenantStudyId).IsRequired();
-            entity.Property(e => e.PseudonymousSubjectNumber).IsRequired();
+            entity.Property(e => e.DepotId).IsRequired();
+            entity.Property(e => e.ParcelNumber).IsRequired();
             entity.Property(e => e.CreatedAtUtc).IsRequired();
-            entity.Property(e => e.LastSeenAtUtc).IsRequired();
+            entity.Property(e => e.LastCheckpointAtUtc).IsRequired();
 
             // Owned JSON payload – contains a nested OwnsMany collection
-            entity.OwnsOne(e => e.PlanPayload, b =>
+            entity.OwnsOne(e => e.ManifestPayload, b =>
             {
                 b.ToJson();
-                b.OwnsMany(p => p.ScheduledItems);
+                b.OwnsMany(p => p.Checkpoints);
             });
         });
 
         // ── Scalar-only sibling view (must continue to work via ToQueryString) ─
-        modelBuilder.Entity<EnrollmentSummaryView>(entity =>
+        modelBuilder.Entity<ShipmentSummaryView>(entity =>
         {
-            entity.ToView("EnrollmentSummaryView")
-                  .HasViewDefinition<EnrollmentSummaryView, EnrollmentContext>(ctx =>
-                      from e in ctx.EnrollmentRecords
-                      select new EnrollmentSummaryView
+            entity.ToView("ShipmentSummaryView")
+                  .HasViewDefinition<ShipmentSummaryView, ShipmentContext>(ctx =>
+                      from e in ctx.ShipmentRecords
+                      select new ShipmentSummaryView
                       {
                           Id = e.Id,
-                          TenantStudyId = e.TenantStudyId,
+                          DepotId = e.DepotId,
                           CreatedAtUtc = e.CreatedAtUtc
                       });
             entity.HasKey(v => v.Id);
         });
 
         // ── View that projects scalars + the JSON-owned navigation ──────────────
-        // This is the failing case: EF Core cannot translate PlanPayload = e.PlanPayload
-        // when PlanPayload is a ToJson()-owned type that also has an OwnsMany inside it.
-        modelBuilder.Entity<RedactedEnrollmentView>(entity =>
+        // This is the failing case: EF Core cannot translate ManifestPayload = e.ManifestPayload
+        // when ManifestPayload is a ToJson()-owned type that also has an OwnsMany inside it.
+        modelBuilder.Entity<ShipmentSnapshotView>(entity =>
         {
-            entity.ToView("RedactedEnrollmentView")
-                  .HasViewDefinition<RedactedEnrollmentView, EnrollmentContext>(ctx =>
-                      from e in ctx.EnrollmentRecords
-                      select new RedactedEnrollmentView
+            entity.ToView("ShipmentSnapshotView")
+                  .HasViewDefinition<ShipmentSnapshotView, ShipmentContext>(ctx =>
+                      from e in ctx.ShipmentRecords
+                      select new ShipmentSnapshotView
                       {
                           Id = e.Id,
-                          TenantStudyId = e.TenantStudyId,
-                          ScopedSubjectNumber = e.PseudonymousSubjectNumber,
+                          DepotId = e.DepotId,
+                          RouteParcelNumber = e.ParcelNumber,
                           CreatedAtUtc = e.CreatedAtUtc,
-                          LastSeenAtUtc = e.LastSeenAtUtc,
-                          WithdrawnAtUtc = e.WithdrawnAtUtc,
-                          CompletedAtUtc = e.CompletedAtUtc,
-                          PlanPayload = e.PlanPayload
+                          LastCheckpointAtUtc = e.LastCheckpointAtUtc,
+                          CancelledAtUtc = e.CancelledAtUtc,
+                          DeliveredAtUtc = e.DeliveredAtUtc,
+                          ManifestPayload = e.ManifestPayload
                       })
                   .WithSchemaBinding()
                   .HasClusteredIndex(v => v.Id);
@@ -849,10 +849,10 @@ public class EnrollmentContext : DbContext
             entity.HasKey(v => v.Id);
 
             // The view also exposes the JSON column so it must carry the same ToJson mapping
-            entity.OwnsOne(v => v.PlanPayload, b =>
+            entity.OwnsOne(v => v.ManifestPayload, b =>
             {
                 b.ToJson();
-                b.OwnsMany(p => p.ScheduledItems);
+                b.OwnsMany(p => p.Checkpoints);
             });
         });
     }
@@ -860,186 +860,200 @@ public class EnrollmentContext : DbContext
 
 // ── Entity / value-object types ────────────────────────────────────────────────
 
-public class EnrollmentRecord
+public class ShipmentRecord
 {
     public int Id { get; set; }
-    public int TenantStudyId { get; set; }
-    public int PseudonymousSubjectNumber { get; set; }
+    public int DepotId { get; set; }
+    public int ParcelNumber { get; set; }
     public DateTime CreatedAtUtc { get; set; }
-    public DateTime LastSeenAtUtc { get; set; }
-    public DateTime? WithdrawnAtUtc { get; set; }
-    public DateTime? CompletedAtUtc { get; set; }
-    public EnrollmentPlanPayload? PlanPayload { get; set; }
+    public DateTime LastCheckpointAtUtc { get; set; }
+    public DateTime? CancelledAtUtc { get; set; }
+    public DateTime? DeliveredAtUtc { get; set; }
+    public ShipmentManifestPayload? ManifestPayload { get; set; }
 }
 
-public class EnrollmentPlanPayload
+public class ShipmentManifestPayload
 {
-    public string? PlanName { get; set; }
-    public DateTime? StartDate { get; set; }
-    public int? DurationDays { get; set; }
-    public List<ScheduledItem> ScheduledItems { get; set; } = new();
+    public string? RouteName { get; set; }
+    public DateTime? DispatchDate { get; set; }
+    public int? TotalMiles { get; set; }
+    public List<ManifestCheckpoint> Checkpoints { get; set; } = new();
 }
 
-public class ScheduledItem
+public class ManifestCheckpoint
 {
-    public string Name { get; set; } = string.Empty;
-    public int DayOffset { get; set; }
+    public string Label { get; set; } = string.Empty;
+    public int Sequence { get; set; }
 }
 
 // ── View projection types ───────────────────────────────────────────────────────
 
-public class EnrollmentSummaryView
+public class ShipmentSummaryView
 {
     public int Id { get; set; }
-    public int TenantStudyId { get; set; }
+    public int DepotId { get; set; }
     public DateTime CreatedAtUtc { get; set; }
 }
 
-public class RedactedEnrollmentView
+public class ShipmentSnapshotView
 {
     public int Id { get; set; }
-    public int TenantStudyId { get; set; }
-    public int ScopedSubjectNumber { get; set; }
+    public int DepotId { get; set; }
+    public int RouteParcelNumber { get; set; }
     public DateTime CreatedAtUtc { get; set; }
-    public DateTime LastSeenAtUtc { get; set; }
-    public DateTime? WithdrawnAtUtc { get; set; }
-    public DateTime? CompletedAtUtc { get; set; }
-    public EnrollmentPlanPayload? PlanPayload { get; set; }
+    public DateTime LastCheckpointAtUtc { get; set; }
+    public DateTime? CancelledAtUtc { get; set; }
+    public DateTime? DeliveredAtUtc { get; set; }
+    public ShipmentManifestPayload? ManifestPayload { get; set; }
 }
 
 /// <summary>
 /// Reproduces a joined view where EF Core's SQL includes hidden materialization keys
 /// when JSON-owned projections and renamed/computed columns are present.
 /// </summary>
-public class JoinedEnrollmentContext : DbContext
+public class ArcadeContext : DbContext
 {
-    public DbSet<JoinedEnrollmentRecord> JoinedEnrollmentRecords { get; set; } = null!;
-    public DbSet<ParticipantProfileRecord> ParticipantProfileRecords { get; set; } = null!;
-    public DbSet<JoinedParticipantProfileView> JoinedParticipantProfileViews { get; set; } = null!;
+    public DbSet<ArcadeSessionRecord> ArcadeSessionRecords { get; set; } = null!;
+    public DbSet<PlayerProfileRecord> PlayerProfileRecords { get; set; } = null!;
+    public DbSet<ArcadeLeaderboardView> ArcadeLeaderboardViews { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         if (!optionsBuilder.IsConfigured)
         {
-            optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=JoinedEnrollmentDb;Trusted_Connection=True;");
+            optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=ArcadeDb;Trusted_Connection=True;");
         }
     }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        modelBuilder.Entity<JoinedEnrollmentRecord>(entity =>
+        modelBuilder.Entity<ArcadeSessionRecord>(entity =>
         {
-            entity.ToTable("JoinedEnrollmentRecords");
+            entity.ToTable("ArcadeSessionRecords");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Id).UseIdentityColumn();
-            entity.Property(e => e.ParticipantId).IsRequired();
-            entity.Property(e => e.TenantStudyId).IsRequired();
-            entity.Property(e => e.PseudonymousSubjectNumber).IsRequired();
+            entity.Property(e => e.PlayerId).IsRequired();
+            entity.Property(e => e.ArcadeId).IsRequired();
+            entity.Property(e => e.TicketNumber).IsRequired();
             entity.Property(e => e.CreatedAtUtc).IsRequired();
-            entity.Property(e => e.LastSeenAtUtc).IsRequired();
-            entity.HasIndex(e => new { e.TenantStudyId, e.PseudonymousSubjectNumber }).IsUnique();
+            entity.Property(e => e.LastPlayedAtUtc).IsRequired();
+            entity.HasIndex(e => new { e.ArcadeId, e.TicketNumber }).IsUnique();
 
-            entity.OwnsOne(e => e.PlanPayload, b =>
+            entity.OwnsOne(e => e.PrizeTrackPayload, b =>
             {
                 b.ToJson();
-                b.OwnsMany(p => p.ScheduledItems);
+                b.OwnsMany(p => p.RewardMilestones);
             });
         });
 
-        modelBuilder.Entity<ParticipantProfileRecord>(entity =>
+        modelBuilder.Entity<PlayerProfileRecord>(entity =>
         {
-            entity.ToTable("ParticipantProfileRecords");
+            entity.ToTable("PlayerProfileRecords");
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Id).UseIdentityColumn();
-            entity.Property(e => e.ParticipantId).IsRequired();
-            entity.HasIndex(e => e.ParticipantId).IsUnique();
+            entity.Property(e => e.PlayerId).IsRequired();
+            entity.HasIndex(e => e.PlayerId).IsUnique();
 
-            entity.OwnsOne(e => e.BackgroundPayload, b =>
+            entity.OwnsOne(e => e.PreferencePayload, b =>
             {
                 b.ToJson();
-                b.OwnsMany(p => p.Flags);
+                b.OwnsMany(p => p.Badges);
             });
         });
 
-        modelBuilder.Entity<JoinedParticipantProfileView>(entity =>
+        modelBuilder.Entity<ArcadeLeaderboardView>(entity =>
         {
-            entity.ToView("JoinedParticipantProfileView")
-                .HasViewDefinition<JoinedParticipantProfileView, JoinedEnrollmentContext>(ctx =>
-                    from enrollment in ctx.JoinedEnrollmentRecords.AsNoTracking()
-                    join profile in ctx.ParticipantProfileRecords.AsNoTracking() on enrollment.ParticipantId equals profile.ParticipantId
-                    select new JoinedParticipantProfileView
+            entity.ToView("ArcadeLeaderboardView")
+                .HasViewDefinition<ArcadeLeaderboardView, ArcadeContext>(ctx =>
+                    from session in ctx.ArcadeSessionRecords.AsNoTracking()
+                    join profile in ctx.PlayerProfileRecords.AsNoTracking() on session.PlayerId equals profile.PlayerId
+                    select new ArcadeLeaderboardView
                     {
-                        TenantStudyId = enrollment.TenantStudyId,
-                        ScopedSubjectNumber = enrollment.PseudonymousSubjectNumber,
-                        BirthYear = profile.BirthDate.HasValue ? profile.BirthDate.Value.Year : 0,
-                        BackgroundPayload = profile.BackgroundPayload,
-                        CreatedAtUtc = enrollment.CreatedAtUtc,
-                        LastSeenAtUtc = enrollment.LastSeenAtUtc,
-                        WithdrawnAtUtc = enrollment.WithdrawnAtUtc,
-                        CompletedAtUtc = enrollment.CompletedAtUtc,
-                        PlanPayload = enrollment.PlanPayload
+                        ArcadeId = session.ArcadeId,
+                        DisplayTicket = session.TicketNumber,
+                        MembershipYear = profile.MemberSince.HasValue ? profile.MemberSince.Value.Year : 0,
+                        PreferencePayload = profile.PreferencePayload,
+                        CreatedAtUtc = session.CreatedAtUtc,
+                        LastPlayedAtUtc = session.LastPlayedAtUtc,
+                        ExpiredAtUtc = session.ExpiredAtUtc,
+                        RedeemedAtUtc = session.RedeemedAtUtc,
+                        PrizeTrackPayload = session.PrizeTrackPayload
                     })
                 .WithSchemaBinding()
-                .HasClusteredIndex(v => new { v.TenantStudyId, v.ScopedSubjectNumber });
+                .HasClusteredIndex(v => new { v.ArcadeId, v.DisplayTicket });
 
-            entity.HasKey(v => new { v.TenantStudyId, v.ScopedSubjectNumber });
+            entity.HasKey(v => new { v.ArcadeId, v.DisplayTicket });
 
-            entity.OwnsOne(v => v.BackgroundPayload, b =>
+            entity.OwnsOne(v => v.PreferencePayload, b =>
             {
                 b.ToJson();
-                b.OwnsMany(p => p.Flags);
+                b.OwnsMany(p => p.Badges);
             });
 
-            entity.OwnsOne(v => v.PlanPayload, b =>
+            entity.OwnsOne(v => v.PrizeTrackPayload, b =>
             {
                 b.ToJson();
-                b.OwnsMany(p => p.ScheduledItems);
+                b.OwnsMany(p => p.RewardMilestones);
             });
         });
     }
 }
 
-public class JoinedEnrollmentRecord
+public class ArcadeSessionRecord
 {
     public int Id { get; set; }
-    public int ParticipantId { get; set; }
-    public int TenantStudyId { get; set; }
-    public int PseudonymousSubjectNumber { get; set; }
+    public int PlayerId { get; set; }
+    public int ArcadeId { get; set; }
+    public int TicketNumber { get; set; }
     public DateTime CreatedAtUtc { get; set; }
-    public DateTime LastSeenAtUtc { get; set; }
-    public DateTime? WithdrawnAtUtc { get; set; }
-    public DateTime? CompletedAtUtc { get; set; }
-    public EnrollmentPlanPayload? PlanPayload { get; set; }
+    public DateTime LastPlayedAtUtc { get; set; }
+    public DateTime? ExpiredAtUtc { get; set; }
+    public DateTime? RedeemedAtUtc { get; set; }
+    public PrizeTrackPayload? PrizeTrackPayload { get; set; }
 }
 
-public class ParticipantProfileRecord
+public class PlayerProfileRecord
 {
     public int Id { get; set; }
-    public int ParticipantId { get; set; }
-    public DateTime? BirthDate { get; set; }
-    public ParticipantBackgroundPayload? BackgroundPayload { get; set; }
+    public int PlayerId { get; set; }
+    public DateTime? MemberSince { get; set; }
+    public PlayerPreferencePayload? PreferencePayload { get; set; }
 }
 
-public class ParticipantBackgroundPayload
+public class PlayerPreferencePayload
 {
-    public string? Summary { get; set; }
-    public List<ParticipantBackgroundFlag> Flags { get; set; } = new();
+    public string? FavoriteGame { get; set; }
+    public List<PlayerBadge> Badges { get; set; } = new();
 }
 
-public class ParticipantBackgroundFlag
+public class PlayerBadge
 {
     public string Value { get; set; } = string.Empty;
 }
 
-public class JoinedParticipantProfileView
+public class PrizeTrackPayload
 {
-    public int TenantStudyId { get; set; }
-    public int ScopedSubjectNumber { get; set; }
-    public int BirthYear { get; set; }
-    public ParticipantBackgroundPayload? BackgroundPayload { get; set; }
+    public string? CampaignName { get; set; }
+    public DateTime? LaunchDate { get; set; }
+    public int? BonusPoints { get; set; }
+    public List<RewardMilestone> RewardMilestones { get; set; } = new();
+}
+
+public class RewardMilestone
+{
+    public string Title { get; set; } = string.Empty;
+    public int Threshold { get; set; }
+}
+
+public class ArcadeLeaderboardView
+{
+    public int ArcadeId { get; set; }
+    public int DisplayTicket { get; set; }
+    public int MembershipYear { get; set; }
+    public PlayerPreferencePayload? PreferencePayload { get; set; }
     public DateTime CreatedAtUtc { get; set; }
-    public DateTime LastSeenAtUtc { get; set; }
-    public DateTime? WithdrawnAtUtc { get; set; }
-    public DateTime? CompletedAtUtc { get; set; }
-    public EnrollmentPlanPayload? PlanPayload { get; set; }
+    public DateTime LastPlayedAtUtc { get; set; }
+    public DateTime? ExpiredAtUtc { get; set; }
+    public DateTime? RedeemedAtUtc { get; set; }
+    public PrizeTrackPayload? PrizeTrackPayload { get; set; }
 }

--- a/tests/Chimpiler.Tests/ChimpilerTests.cs
+++ b/tests/Chimpiler.Tests/ChimpilerTests.cs
@@ -646,19 +646,19 @@ public class DacpacGeneratorTests : IDisposable
     {
         var logMessages = new List<string>();
         var generator = new DacpacGenerator(msg => logMessages.Add(msg));
-        var outputPath = Path.Combine(_tempOutputDir, "Enrollment.dacpac");
+        var outputPath = Path.Combine(_tempOutputDir, "Shipment.dacpac");
 
-        generator.GenerateDacpac(typeof(EnrollmentContext), outputPath);
+        generator.GenerateDacpac(typeof(ShipmentContext), outputPath);
 
         Assert.True(File.Exists(outputPath));
         using var model = TSqlModel.LoadFromDacpac(outputPath, new ModelLoadOptions());
 
         var views = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.View).ToList();
-        Assert.Contains(views, v => v.Name.Parts.Any(p => p == "EnrollmentSummaryView"));
+        Assert.Contains(views, v => v.Name.Parts.Any(p => p == "ShipmentSummaryView"));
 
         // The scalar-only view should have been generated via the normal ToQueryString() path,
         // not the expression-tree fallback, so no fallback log message should appear for it.
-        Assert.DoesNotContain(logMessages, m => m.Contains("fallback") && m.Contains("EnrollmentSummaryView"));
+        Assert.DoesNotContain(logMessages, m => m.Contains("fallback") && m.Contains("ShipmentSummaryView"));
     }
 
     /// <summary>
@@ -672,19 +672,19 @@ public class DacpacGeneratorTests : IDisposable
     {
         var logMessages = new List<string>();
         var generator = new DacpacGenerator(msg => logMessages.Add(msg));
-        var outputPath = Path.Combine(_tempOutputDir, "Enrollment.dacpac");
+        var outputPath = Path.Combine(_tempOutputDir, "Shipment.dacpac");
 
-        // Must not throw even though EF Core cannot translate PlanPayload = e.PlanPayload
-        generator.GenerateDacpac(typeof(EnrollmentContext), outputPath);
+        // Must not throw even though EF Core cannot translate ManifestPayload = e.ManifestPayload
+        generator.GenerateDacpac(typeof(ShipmentContext), outputPath);
 
         Assert.True(File.Exists(outputPath));
         using var model = TSqlModel.LoadFromDacpac(outputPath, new ModelLoadOptions());
 
         var views = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.View).ToList();
-        Assert.Contains(views, v => v.Name.Parts.Any(p => p == "RedactedEnrollmentView"));
+        Assert.Contains(views, v => v.Name.Parts.Any(p => p == "ShipmentSnapshotView"));
 
-        Assert.Contains(logMessages, m => m.Contains("No-tracking retry succeeded") && m.Contains("RedactedEnrollmentView"));
-        Assert.DoesNotContain(logMessages, m => m.Contains("fallback") && m.Contains("RedactedEnrollmentView"));
+        Assert.Contains(logMessages, m => m.Contains("No-tracking retry succeeded") && m.Contains("ShipmentSnapshotView"));
+        Assert.DoesNotContain(logMessages, m => m.Contains("fallback") && m.Contains("ShipmentSnapshotView"));
     }
 
     /// <summary>
@@ -696,18 +696,18 @@ public class DacpacGeneratorTests : IDisposable
     public void GenerateDacpac_ForViewWithOwnedJsonContainingCollection_SelectsJsonColumn()
     {
         var logs = new List<string>();
-        using var ctx = new EnrollmentContext();
-        var viewEntityType = ctx.Model.FindEntityType(typeof(RedactedEnrollmentView))!;
+        using var ctx = new ShipmentContext();
+        var viewEntityType = ctx.Model.FindEntityType(typeof(ShipmentSnapshotView))!;
         var generator = new ViewSqlGenerator(msg => logs.Add(msg));
 
         var viewDdl = generator.GenerateViewDdl(viewEntityType, ctx);
 
-        // The generated SELECT must include the PlanPayload JSON column
-        Assert.Contains("PlanPayload", viewDdl, StringComparison.OrdinalIgnoreCase);
+        // The generated SELECT must include the ManifestPayload JSON column
+        Assert.Contains("ManifestPayload", viewDdl, StringComparison.OrdinalIgnoreCase);
         // The view body must reference the source table
-        Assert.Contains("EnrollmentRecords", viewDdl, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains(logs, m => m.Contains("No-tracking retry succeeded") && m.Contains("RedactedEnrollmentView"));
-        Assert.DoesNotContain(logs, m => m.Contains("fallback") && m.Contains("RedactedEnrollmentView"));
+        Assert.Contains("ShipmentRecords", viewDdl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(logs, m => m.Contains("No-tracking retry succeeded") && m.Contains("ShipmentSnapshotView"));
+        Assert.DoesNotContain(logs, m => m.Contains("fallback") && m.Contains("ShipmentSnapshotView"));
     }
 
     /// <summary>
@@ -718,34 +718,34 @@ public class DacpacGeneratorTests : IDisposable
     public void GenerateDacpac_ForSchemaBindingIndexedViewWithJsonProjection_ShouldWork()
     {
         var generator = new DacpacGenerator();
-        var outputPath = Path.Combine(_tempOutputDir, "Enrollment.dacpac");
+        var outputPath = Path.Combine(_tempOutputDir, "Shipment.dacpac");
 
-        generator.GenerateDacpac(typeof(EnrollmentContext), outputPath);
+        generator.GenerateDacpac(typeof(ShipmentContext), outputPath);
 
         Assert.True(File.Exists(outputPath));
         using var model = TSqlModel.LoadFromDacpac(outputPath, new ModelLoadOptions());
 
         var views = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.View).ToList();
-        var redactedView = views.FirstOrDefault(v => v.Name.Parts.Any(p => p == "RedactedEnrollmentView"));
-        Assert.NotNull(redactedView);
+        var shipmentView = views.FirstOrDefault(v => v.Name.Parts.Any(p => p == "ShipmentSnapshotView"));
+        Assert.NotNull(shipmentView);
 
         // A unique clustered index must have been added for HasClusteredIndex(v => v.Id)
         var indexes = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Index).ToList();
-        Assert.Contains(indexes, idx => idx.Name.Parts.Any(p => p.Contains("RedactedEnrollmentView")));
+        Assert.Contains(indexes, idx => idx.Name.Parts.Any(p => p.Contains("ShipmentSnapshotView")));
     }
 
     [Fact]
     public void GenerateViewDdl_ForJoinedViewWithJsonProjection_ShouldRestoreProjectionAliases()
     {
-        using var ctx = new JoinedEnrollmentContext();
-        var viewEntityType = ctx.Model.FindEntityType(typeof(JoinedParticipantProfileView))!;
+        using var ctx = new ArcadeContext();
+        var viewEntityType = ctx.Model.FindEntityType(typeof(ArcadeLeaderboardView))!;
         var logs = new List<string>();
         var generator = new ViewSqlGenerator(msg => logs.Add(msg));
 
         var viewDdl = generator.GenerateViewDdl(viewEntityType, ctx);
 
-        Assert.Contains("[PseudonymousSubjectNumber] AS [ScopedSubjectNumber]", viewDdl, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("AS [BirthYear]", viewDdl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("[TicketNumber] AS [DisplayTicket]", viewDdl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AS [MembershipYear]", viewDdl, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain(" AS [Id]", viewDdl, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(logs, m => m.Contains("Projection normalization trimmed", StringComparison.OrdinalIgnoreCase));
     }
@@ -754,18 +754,18 @@ public class DacpacGeneratorTests : IDisposable
     public void GenerateDacpac_ForJoinedViewWithJsonProjectionAndCompositeIndex_ShouldWork()
     {
         var generator = new DacpacGenerator();
-        var outputPath = Path.Combine(_tempOutputDir, "JoinedEnrollment.dacpac");
+        var outputPath = Path.Combine(_tempOutputDir, "Arcade.dacpac");
 
-        generator.GenerateDacpac(typeof(JoinedEnrollmentContext), outputPath);
+        generator.GenerateDacpac(typeof(ArcadeContext), outputPath);
 
         Assert.True(File.Exists(outputPath));
         using var model = TSqlModel.LoadFromDacpac(outputPath, new ModelLoadOptions());
 
         var views = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.View).ToList();
-        Assert.Contains(views, v => v.Name.Parts.Any(p => p == "JoinedParticipantProfileView"));
+        Assert.Contains(views, v => v.Name.Parts.Any(p => p == "ArcadeLeaderboardView"));
 
         var indexes = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Index).ToList();
-        Assert.Contains(indexes, idx => idx.Name.Parts.Any(p => p.Contains("JoinedParticipantProfileView")));
+        Assert.Contains(indexes, idx => idx.Name.Parts.Any(p => p.Contains("ArcadeLeaderboardView")));
     }
 }
 

--- a/tests/Chimpiler.Tests/ChimpilerTests.cs
+++ b/tests/Chimpiler.Tests/ChimpilerTests.cs
@@ -733,6 +733,40 @@ public class DacpacGeneratorTests : IDisposable
         var indexes = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Index).ToList();
         Assert.Contains(indexes, idx => idx.Name.Parts.Any(p => p.Contains("RedactedEnrollmentView")));
     }
+
+    [Fact]
+    public void GenerateViewDdl_ForJoinedViewWithJsonProjection_ShouldRestoreProjectionAliases()
+    {
+        using var ctx = new JoinedEnrollmentContext();
+        var viewEntityType = ctx.Model.FindEntityType(typeof(JoinedParticipantProfileView))!;
+        var logs = new List<string>();
+        var generator = new ViewSqlGenerator(msg => logs.Add(msg));
+
+        var viewDdl = generator.GenerateViewDdl(viewEntityType, ctx);
+
+        Assert.Contains("[PseudonymousSubjectNumber] AS [ScopedSubjectNumber]", viewDdl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AS [BirthYear]", viewDdl, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(" AS [Id]", viewDdl, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(logs, m => m.Contains("Projection normalization trimmed", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void GenerateDacpac_ForJoinedViewWithJsonProjectionAndCompositeIndex_ShouldWork()
+    {
+        var generator = new DacpacGenerator();
+        var outputPath = Path.Combine(_tempOutputDir, "JoinedEnrollment.dacpac");
+
+        generator.GenerateDacpac(typeof(JoinedEnrollmentContext), outputPath);
+
+        Assert.True(File.Exists(outputPath));
+        using var model = TSqlModel.LoadFromDacpac(outputPath, new ModelLoadOptions());
+
+        var views = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.View).ToList();
+        Assert.Contains(views, v => v.Name.Parts.Any(p => p == "JoinedParticipantProfileView"));
+
+        var indexes = model.GetObjects(DacQueryScopes.UserDefined, ModelSchema.Index).ToList();
+        Assert.Contains(indexes, idx => idx.Name.Parts.Any(p => p.Contains("JoinedParticipantProfileView")));
+    }
 }
 
 public class EfMigrateServiceTests : IDisposable


### PR DESCRIPTION
## Summary
- normalize SELECT columns back to the declared view projection for Join result selectors before building the DACPAC
- trim hidden EF materialization keys and restore projection aliases for joined JSON-backed view projections
- cover the regression with joined-view DACPAC and DDL tests

## Root cause
EF ToQueryString for joined JSON-backed view projections included hidden materialization keys and dropped projection aliases.

## Fix
Normalize SELECT columns back to the declared view projection for Join result selectors before building the DACPAC.

## Verification
- chimpiler tests pass
- backend ef-migrate for ParticipantsDbContext now succeeds
- backend dbup-cloud to dev gets past chimpiler and then fails later on an unrelated sqlpackage data-loss guard in Trials/UserEntity